### PR TITLE
CleanUp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,29 @@ An ansible role to update all packages (multiplatform)
 * Suse
 * Kali GNU/Linux
 
+# Installation
+
+## Ansible galaxy
+
+The role is available on [Ansible Galaxy](https://galaxy.ansible.com/ui/standalone/roles/stafwag/package_update/).
+
+To install the role from Ansible Galaxy execute the command below. 
+
+```bash
+ansible-galaxy install stafwag.package_update
+```
+## Source Code
+
+If you want to use the source code directly.
+
+Clone the role source code.
+
+```bash
+$ git clone https://github.com/stafwag/ansible-role-package_update
+```
+
+and put into the [role search path](https://docs.ansible.com/ansible/2.4/playbooks_reuse_roles.html#role-search-path)
+
 ## Role Variables
 ### OS related variables
 
@@ -104,4 +127,4 @@ MIT/BSD
 
 ## Author Information
 
-Created by Staf Wagemakers, email: staf@wagemakers.be, website: http://www.wagemakers.be
+Created by Staf Wagemakers, email: staf@wagemakers.be, website: https://www.wagemakers.be, my company: https://mask27.dev

--- a/doc/examples/upgrade_localhost.yml
+++ b/doc/examples/upgrade_localhost.yml
@@ -1,0 +1,6 @@
+---
+- name: update packages
+  hosts: localhost
+  become: true
+  roles:
+    - stafwag.package_update

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,7 @@
+---
 galaxy_info:
   role_name: package_update
+  namespace: stafwag
   author: staf wagemakers <staf@wagemakers.be>
   description: Update all packages (multiplatform)
   license: license BSD, MIT)
@@ -7,39 +9,31 @@ galaxy_info:
   platforms:
     - name: EL
       versions:
-        - all
+        - "all"
     - name: Fedora
       versions:
-        - all
+        - "all"
     - name: Debian
       versions:
-        - all
+        - "all"
     - name: Ubuntu
       versions:
-        - all
+        - "all"
     - name: opensuse
       versions:
-        - all
+        - "all"
     - name: SLES
       versions:
-        - all
-    - name: Archlinux
+        - "all"
+    - name: ArchLinux
       versions:
-        - all
+        - "all"
     - name: FreeBSD
       versions:
-        - 10.0
-        - 10.1
-        - 10.2
-        - 10.3
-        - 10.4
-        - 11.0
-        - 11.1
-        - 11.2
-        - 12.0
+        - "all"
     - name: OpenBSD
       versions:
-        - all
+        - "all"
   galaxy_tags:
     - system
     - packaging

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,4 +8,3 @@
     - 'update/{{ ansible_pkg_mgr }}.yml'
     - 'update/{{ ansible_distribution }}.yml'
     - 'update/{{ ansible_os_family }}.yml'
-    - 'update/{{ ansible_os_family | replace ("/","_") | replace(" ","_") }}.yml'

--- a/tasks/update/Archlinux.yml
+++ b/tasks/update/Archlinux.yml
@@ -1,4 +1,5 @@
+---
 - name: pacman update
-  pacman:
-    update_cache: yes
-    upgrade: yes
+  community.general.pacman:
+    update_cache: true
+    upgrade: true

--- a/tasks/update/CentOS-5.yml
+++ b/tasks/update/CentOS-5.yml
@@ -1,7 +1,8 @@
+---
 - name: yum check-update
-  command: yum check-update
+  command: yum check-update # noqa command-instead-of-module
   register: yum_check_update
   changed_when: "yum_check_update.rc != 0"
 - name: run yum update -y
-  command: yum update -y
+  command: yum update -y # noqa command-instead-of-module
   when: "yum_check_update.rc != 0"

--- a/tasks/update/Debian.yml
+++ b/tasks/update/Debian.yml
@@ -1,11 +1,12 @@
+---
 - name: Update apt cache
-  apt:
-    update_cache: yes
-  changed_when: False
+  ansible.builtin.apt:
+    update_cache: true
+  changed_when: false
 - name: install aptitude
-  apt: name=aptitude state=latest
+  ansible.builtin.apt: name=aptitude state=present
 - name: Upgrade all
-  apt:
+  ansible.builtin.apt:
     upgrade: dist
-    autoclean: yes
-    autoremove: yes
+    autoclean: true
+    autoremove: true

--- a/tasks/update/FreeBSD.yml
+++ b/tasks/update/FreeBSD.yml
@@ -1,3 +1,4 @@
+---
 - name: set _update_freebsd_host
   set_fact:
     _update_freebsd_host: '{{ package_update.freebsd.host | default(true) }}'

--- a/tasks/update/FreeBSD/get_running_jails.yml
+++ b/tasks/update/FreeBSD/get_running_jails.yml
@@ -1,7 +1,13 @@
+---
 - name: execute jls
-  shell: jls | sed 1d | awk '{ print $3 }'
+  shell: |
+    set -o errexit
+    set -o pipefail
+    set -o nounset
+
+    jls | sed 1d | awk '{ print $3 }'
   register: cmd_jail_id_list
-  changed_when: False
+  changed_when: false
 - name: set freebsd_running_jails
   set_fact:
     freebsd_running_jails: '{{ cmd_jail_id_list.stdout_lines }}'

--- a/tasks/update/FreeBSD/update.yml
+++ b/tasks/update/FreeBSD/update.yml
@@ -1,3 +1,4 @@
+---
 - name: set my_pkg_cmd var for host
   set_fact:
     my_pkg_cmd: pkg

--- a/tasks/update/Kali_GNU_Linux.yml
+++ b/tasks/update/Kali_GNU_Linux.yml
@@ -1,1 +1,0 @@
-Debian.yml

--- a/tasks/update/NetBSD.yml
+++ b/tasks/update/NetBSD.yml
@@ -1,4 +1,5 @@
+---
 - name: pkgin update
   pkgin:
-    full_upgrade: yes
-    force: yes
+    full_upgrade: true
+    force: true

--- a/tasks/update/OpenBSD.yml
+++ b/tasks/update/OpenBSD.yml
@@ -1,4 +1,5 @@
+---
 - name: OpenBSD update
-  openbsd_pkg:
+  community.general.openbsd_pkg:
     name: '*'
     state: latest

--- a/tasks/update/RedHat.yml
+++ b/tasks/update/RedHat.yml
@@ -1,2 +1,3 @@
+---
 - name: yum update all
-  yum: name=* state=latest
+  ansible.builtin.yum: name=* state=latest # noqa package-latest

--- a/tasks/update/Solaris.yml
+++ b/tasks/update/Solaris.yml
@@ -1,3 +1,4 @@
+---
 - name: update solaris
   debug:
     msg: Not implemented yet

--- a/tasks/update/Suse.yml
+++ b/tasks/update/Suse.yml
@@ -1,4 +1,5 @@
+---
 - name: SLES Update packages
-  zypper:
+  community.general.zypper:
     name: '*'
     state: latest

--- a/tasks/update/dnf.yml
+++ b/tasks/update/dnf.yml
@@ -1,2 +1,3 @@
+---
 - name: dnf update all
-  dnf: name=* state=latest
+  ansible.builtin.dnf: name=* state=latest # noqa package-latest


### PR DESCRIPTION
* Corrected ansible-lint errors
* Removed replace space to include ansible_os_family tasks
    It was used for Kali GNU/Linux, Kali is reported as Debian now.
* Updated meta data
* Updated documentation