### PR TITLE
3 correct ansible lint errors

### DIFF
--- a/doc/examples/upgrade_all_hosts.yml
+++ b/doc/examples/upgrade_all_hosts.yml
@@ -1,0 +1,6 @@
+---
+- name: update packages
+  hosts: all
+  become: true
+  roles:
+    - stafwag.package_update

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: staf wagemakers <staf@wagemakers.be>
   description: Update all packages (multiplatform)
   license: license BSD, MIT)
-  min_ansible_version: 2.4
+  min_ansible_version: "2.4"
   platforms:
     - name: EL
       versions:
@@ -32,6 +32,9 @@ galaxy_info:
       versions:
         - "all"
     - name: OpenBSD
+      versions:
+        - "all"
+    - name: NetBSD
       versions:
         - "all"
   galaxy_tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for ansible-role-package_update
 
-- name: execute OS related tasks
-  include_tasks: "{{ item }}"
+- name: Execute OS related tasks
+  ansible.builtin.include_tasks: "{{ item }}"
   with_first_found:
-    - 'update/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml'
-    - 'update/{{ ansible_pkg_mgr }}.yml'
-    - 'update/{{ ansible_distribution }}.yml'
-    - 'update/{{ ansible_os_family }}.yml'
+    - "update/{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "update/{{ ansible_pkg_mgr }}.yml"
+    - "update/{{ ansible_distribution }}.yml"
+    - "update/{{ ansible_os_family }}.yml"

--- a/tasks/update/Archlinux.yml
+++ b/tasks/update/Archlinux.yml
@@ -1,5 +1,5 @@
 ---
-- name: pacman update
+- name: Pacman update
   community.general.pacman:
     update_cache: true
     upgrade: true

--- a/tasks/update/CentOS-5.yml
+++ b/tasks/update/CentOS-5.yml
@@ -1,8 +1,10 @@
 ---
-- name: yum check-update
-  command: yum check-update # noqa command-instead-of-module
+- name: Yum check-update
+  ansible.builtin.command: yum check-update # noqa command-instead-of-module
   register: yum_check_update
   changed_when: "yum_check_update.rc != 0"
-- name: run yum update -y
-  command: yum update -y # noqa command-instead-of-module
+- name: Run yum update -y
+  ansible.builtin.command: yum update -y # noqa command-instead-of-module
+  register: yum_update
+  changed_when: "yum_update.rc == 0"
   when: "yum_check_update.rc != 0"

--- a/tasks/update/Debian.yml
+++ b/tasks/update/Debian.yml
@@ -3,8 +3,10 @@
   ansible.builtin.apt:
     update_cache: true
   changed_when: false
-- name: install aptitude
-  ansible.builtin.apt: name=aptitude state=present
+- name: Install aptitude
+  ansible.builtin.apt:
+    name: aptitude
+    state: present
 - name: Upgrade all
   ansible.builtin.apt:
     upgrade: dist

--- a/tasks/update/FreeBSD.yml
+++ b/tasks/update/FreeBSD.yml
@@ -1,29 +1,29 @@
 ---
-- name: set _update_freebsd_host
-  set_fact:
-    _update_freebsd_host: '{{ package_update.freebsd.host | default(true) }}'
+- name: Set _update_freebsd_host
+  ansible.builtin.set_fact:
+    _update_freebsd_host: "{{ package_update.freebsd.host | default(true) }}"
 
-- name: set _get_running_jails
-  set_fact:
-    _get_running_jails: '{{ package_update.freebsd.get_running_fails | default(true) }}'
+- name: Set _get_running_jails
+  ansible.builtin.set_fact:
+    _get_running_jails: "{{ package_update.freebsd.get_running_fails | default(true) }}"
 
-- name: get the running jails
-  include_tasks: FreeBSD/get_running_jails.yml
+- name: Get the running jails
+  ansible.builtin.include_tasks: FreeBSD/get_running_jails.yml
   when:
     - _get_running_jails
 
-- name: set _update_freebsd_jails
-  set_fact:
-    _update_freebsd_jails: '{{ package_update.freebsd.jails | default( freebsd_running_jails) }}'
+- name: Set _update_freebsd_jails
+  ansible.builtin.set_fact:
+    _update_freebsd_jails: "{{ package_update.freebsd.jails | default(freebsd_running_jails) }}"
 
-- name: add id 0 to the list to update the host system
-  set_fact:
-    _update_freebsd_jails: '{{ [ 0 ] + _update_freebsd_jails }}'
+- name: Add id 0 to the list to update the host system
+  ansible.builtin.set_fact:
+    _update_freebsd_jails: "{{ [0] + _update_freebsd_jails }}"
   when:
     - _update_freebsd_host
 
-- name: update jails
-  include_tasks: FreeBSD/update.yml
+- name: Update jails
+  ansible.builtin.include_tasks: FreeBSD/update.yml
   loop: "{{ _update_freebsd_jails | default(omit) }}"
   loop_control:
     loop_var: jail_id

--- a/tasks/update/FreeBSD/get_running_jails.yml
+++ b/tasks/update/FreeBSD/get_running_jails.yml
@@ -1,6 +1,6 @@
 ---
-- name: execute jls
-  shell: |
+- name: Execute jls
+  ansible.builtin.shell: |
     set -o errexit
     set -o pipefail
     set -o nounset
@@ -8,6 +8,6 @@
     jls | sed 1d | awk '{ print $3 }'
   register: cmd_jail_id_list
   changed_when: false
-- name: set freebsd_running_jails
-  set_fact:
-    freebsd_running_jails: '{{ cmd_jail_id_list.stdout_lines }}'
+- name: Set freebsd_running_jails
+  ansible.builtin.set_fact:
+    freebsd_running_jails: "{{ cmd_jail_id_list.stdout_lines }}"

--- a/tasks/update/FreeBSD/update.yml
+++ b/tasks/update/FreeBSD/update.yml
@@ -1,23 +1,24 @@
 ---
-- name: set my_pkg_cmd var for host
-  set_fact:
+- name: Set my_pkg_cmd var for host
+  ansible.builtin.set_fact:
     my_pkg_cmd: pkg
   when:
     - jail_id == 0
-- name: set my_pkg_cmd for jail
-  set_fact:
-    my_pkg_cmd: 'pkg -j {{ jail_id }}'
+- name: Set my_pkg_cmd for jail
+  ansible.builtin.set_fact:
+    my_pkg_cmd: "pkg -j {{ jail_id }}"
   when:
     - jail_id != 0
-- name: 'pkg update {{ jail_id }}'
-  command: '{{ my_pkg_cmd }} update'
+- name: "Run pkg update {{ jail_id }}"
+  ansible.builtin.command: "{{ my_pkg_cmd }} update"
   register: pkg_update_y
   changed_when: "pkg_update_y.rc != 0"
-- name: 'verify if there are upgrades available {{ jail_id }}'
-  command: '{{ my_pkg_cmd }} upgrade -n'
+- name: "Verify if there are upgrades available {{ jail_id }}"
+  ansible.builtin.command: "{{ my_pkg_cmd }} upgrade -n"
   register: pkg_upgrade_n
   changed_when: "pkg_upgrade_n.rc != 0"
   failed_when: "pkg_upgrade_n.rc > 1"
-- name: 'upgrade {{ jail_id }}'
-  command: '{{ my_pkg_cmd }} upgrade -y'
+- name: "Upgrade {{ jail_id }}"
+  ansible.builtin.command: "{{ my_pkg_cmd }} upgrade -y"
+  changed_when: true
   when: "pkg_upgrade_n.rc != 0"

--- a/tasks/update/NetBSD.yml
+++ b/tasks/update/NetBSD.yml
@@ -1,5 +1,5 @@
 ---
-- name: pkgin update
-  pkgin:
+- name: Pkgin update
+  community.general.pkgin:
     full_upgrade: true
     force: true

--- a/tasks/update/RedHat.yml
+++ b/tasks/update/RedHat.yml
@@ -1,3 +1,1 @@
----
-- name: yum update all
-  ansible.builtin.yum: name=* state=latest # noqa package-latest
+dnf.yml

--- a/tasks/update/Solaris.yml
+++ b/tasks/update/Solaris.yml
@@ -1,4 +1,4 @@
 ---
-- name: update solaris
-  debug:
+- name: Update solaris
+  ansible.builtin.debug:
     msg: Not implemented yet

--- a/tasks/update/dnf.yml
+++ b/tasks/update/dnf.yml
@@ -1,3 +1,5 @@
 ---
-- name: dnf update all
-  ansible.builtin.dnf: name=* state=latest # noqa package-latest
+- name: Upgrade all packages with dnf
+  ansible.builtin.dnf:
+    name: "*"
+    state: latest # noqa package-latest


### PR DESCRIPTION
Corrected ansible-lint errors

* Corrected ansible-lint errors
* Use dnf for the RedHat os family
    * The dnf ansible module suports yum backend now
* The dnf ansible module suports yum backend now
* Meta data updated
    * Corrected ansible-lint errors
    * Added NetBSD to to the platforms
* Added upgrade all example